### PR TITLE
Adding baseline template for Terraform Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ Process to run hcdiag and share the results with HashiCorp:
 - Set the necessary environment variables so hcdiag can query the product:
   - For Vault Enterprise, the `VAULT_TOKEN` and `VAULT_ADDR` environment variables must be set
   - For Terraform Enterprise, the `TFE_TOKEN` and `TFE_HTTP_ADDR` environment variables must be set
+  - For Terraform Cloud, the `TFE_TOKEN` and `TFE_HTTP_ADDR` environment variables must be set. In addition, configure a `TFE_ORG` variable to identify your Terraform Cloud Organization.
   - For Consul Enterprise, the `CONSUL_TOKEN` and `CONSUL_HTTP_ADDR` environment variables must be set
 - hcdiag is best run by a superuser account or the account running the respective product
 - Run hcdiag with specific configuration:
   - Vault Enterprise: `hcdiag -vault -config /path/to/hcdiag_vault.hcl`
-  - Terraform Enterprise: `hcdiag -terraform -config /path/to/hcdiag_terraform.hcl`
+  - Terraform Enterprise: `hcdiag -terraform-ent -config /path/to/hcdiag_terraform.hcl`
+  - Terraform Cloud: `hcdiag -terraform-ent -config /path/to/hcdiag_terraform_cloud.hcl`
   - Consul Enterprise: `hcdiag -consul -config /path/to/hcdiag_consul.hcl`
 - Submit the bundle to HashiCorp via the HashiCorp SendSafely portal link shared by your CSM
 

--- a/hcdiag_terraform_cloud.hcl
+++ b/hcdiag_terraform_cloud.hcl
@@ -1,0 +1,131 @@
+# This sample script illustrates the use of the Terraform Cloud API to gather 
+# information about an organization's entitlements and activation status. The 
+# purpose is to help an administrator validate the feature set assembled to 
+# support workflow activities.
+# The TFE_HTTP_ADDR points to the baseline URL is expressed as follows:
+#
+# export TFE_HTTP_ADDR=https://app.terraform.io 
+#
+# We use TFE_TOKEN instead of TFC_TOKEN to maintain legacy compatibility in 
+# the naming convention. hcdiag is hard-coded to interpret TFE_TOKEN.
+#
+# export TFE_TOKEN="YOUR_TFC_TOKEN_HERE"
+#
+# For this diagnostics exercises, the name of the TFC organization needs to be
+# expressed. Because hcdiag does not support variable inheritance from the 
+# command line, we need to replace the `TFE_ORG` placeholder in this template
+# with your expressed variable.
+# 
+# export TFE_ORG="YOUR_TFC_ORGANIZATION_NAME"
+#
+# In OSX or Linux you can use the following command, or just run find/replace.
+#
+# sed -i '' "s|TFE_ORG|${TFE_ORG}|g" hcdiag_terraform_cloud.hcl
+# 
+# ---
+# hcdiag beta: Terraform Enterprise checks
+
+host {
+  selects = [ # Basic OS Configuration Check
+              "uname -a",
+              "command -v jq"
+            ]
+
+  # Check the operating environment from which
+  # we are running these commands.
+
+  command {
+    run = "uname -a"
+    format = "string"
+  }
+
+  # Check for the `jq` utility operator, used 
+  # to apply filtering commands on JSON data responses.
+
+  command {
+    run = "command -v jq"
+    format = "string"
+  }
+}
+
+# Check for features and entitlements in a Terraform Cloud organization
+
+product "terraform-ent" {
+  selects = [ # Executive Checks
+
+              # Configuration Checks
+              "GET /_health_check?full=1",
+
+              # Terraform Cloud Entitlements
+              "GET /api/v2/organizations/TFE_ORG",
+              "GET /api/v2/organizations/TFE_ORG/entitlement-set",
+              "GET /api/v2/organizations/TFE_ORG/subscription",
+              "GET /api/v2/organizations/TFE_ORG/agent-pools",
+              "GET /api/v2/organizations/TFE_ORG/varsets",
+              "GET /api/v2/organizations/TFE_ORG/tasks",
+              "GET /api/v2/organizations/TFE_ORG/policies",
+              "GET /api/v2/organizations/TFE_ORG/policy-sets",
+              "GET /api/v2/organizations/TFE_ORG/registry-modules",
+              "GET /api/v2/organizations/TFE_ORG/teams",
+              "GET /api/v2/organizations/TFE_ORG/vcs-events"
+            ]
+
+# Show the full set for a Terraform Cloud Organization
+  GET {
+    path = "/api/v2/organizations/TFE_ORG"
+  }
+
+# Get subscription entitlement
+  GET {
+    path = "/api/v2/organizations/TFE_ORG/entitlement-set"
+  }
+
+# Show the subscription leves for a Terraform Cloud Organization
+  GET {
+    path = "/api/v2/organizations/TFE_ORG/subscription"
+  }
+
+# This endpoint allows you to list agent pools, their agents, and their 
+# TFE_TOKENs for the organization identified.
+  GET {
+    path = "/api/v2/organizations/TFE_ORG/agent-pools"
+  }
+
+# List all variable sets for an organization.
+  GET {
+    path = "/api/v2/organizations/TFE_ORG/varsets"
+  }
+
+# This endpoint lists all run taks available in the organization. 
+# This endpoint supports pagination.
+  GET {
+    path = "/api/v2/organizations/TFE_ORG/tasks"
+  }
+
+# This endpoint lists the policies linked in organization.
+  GET {
+    path = "/api/v2/organizations/TFE_ORG/policies"
+  }
+
+# This endpoint lists the policy sets linked in the organization.
+  GET {
+    path = "/api/v2/organizations/TFE_ORG/policy-sets"
+  }
+
+# This enpoint lists the modules that are available to a given organization. 
+# This includes the full list of publicly curated and private modules and is filterable.
+  GET {
+    path = "/api/v2/organizations/TFE_ORG/registry-modules"
+  }
+
+# This endpoint lists all available teams in an organization. Users can view 
+# visible teams and any secret teams and their membership.
+  GET {
+    path = "/api/v2/organizations/TFE_ORG/teams"
+  }
+
+# This endpoint lists VCS events for an organization. 
+  GET {
+    path = "/api/v2/organizations/TFE_ORG/vcs-events"
+  }
+}


### PR DESCRIPTION
This example adds a baseline to use the Terraform Cloud API to gather information about an organization's entitlements and activation status.