### PR TITLE
Remove replicatedctl dependency

### DIFF
--- a/hcdiag_terraform.hcl
+++ b/hcdiag_terraform.hcl
@@ -12,15 +12,14 @@ host {
 
 product "terraform-ent" {
   selects = [
-              "replicatedctl license inspect",
+              "GET /api/v2/admin/release",
               "GET /api/v2/admin/runs?page%5Bsize%5D=1",
               "GET /api/v2/admin/workspaces?page%5Bsize%5D=1",
             ]
 
-# check license and version
-  command {
-    run = "replicatedctl license inspect"
-    format = "json"
+# check version
+  GET {
+    path = "/api/v2/admin/release"
   }
 
 # check features in use '.meta."status-counts"."policy-checked"' & '.meta."status-counts"."cost-estimated"' & '.meta."status-counts"."post-plan-completed"'


### PR DESCRIPTION
Drop the "license validity" check (`replicatedctl license inspect`) from hcdiag-ext as it's the only check left that requires the tool to be on the TFE instance. Without this check, both vault and terraform checks can now all be run remotely from a SRE/Sec/Ops laptop that has a network route to the environment and the necessary env vars. I think this will reduce a lot of friction with getting customers to run hcdiag-ext.